### PR TITLE
Upgrade required PHP version. Change how issuer name is constructed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,20 @@
     "homepage": "http://github.com/nticaric/fiskalizacija",
     "license": "MIT",
     "type": "library",
-    "authors": [{
-        "name": "Nenad Ticaric",
-        "email": "nticaric@gmail.com"
-    }],
+    "authors": [
+        {
+            "name": "Nenad Ticaric",
+            "email": "nticaric@gmail.com"
+        },
+        {
+            "name": "Goran Hrženjak",
+            "email": "goran.hrzenjak@bornfight.com"
+        }
+    ],
     "require": {
-        "php": ">=5.3.0",
-        "nesbot/carbon": "~1.0"
+        "php": ">=7.4",
+        "nesbot/carbon": "~1.0",
+        "ext-openssl": "*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/src/Fiskalizacija.php
+++ b/src/Fiskalizacija.php
@@ -92,8 +92,7 @@ class Fiskalizacija
 
         $SignedInfoNode = $XMLRequestDOMDoc->getElementsByTagName('SignedInfo')->item(0);
 
-        $X509Issuer = $this->publicCertificateData['issuer'];
-        $X509IssuerName = sprintf('OU=%s,O=%s,C=%s', $X509Issuer['OU'], $X509Issuer['O'], $X509Issuer['C']);
+        $X509IssuerName = $this->getIssuerName();
         $X509IssuerSerial = $this->publicCertificateData['serialNumber'];
 
         $publicCertificatePureString = str_replace('-----BEGIN CERTIFICATE-----', '', $this->certificate['cert']);
@@ -221,6 +220,19 @@ class Fiskalizacija
             }
         }
 
+    }
+
+    private function getIssuerName(): string
+    {
+        $X509Issuer = $this->publicCertificateData['issuer'];
+        return implode(
+            ',',
+            array_map(
+                fn (string $key, string $value) => sprintf('%s=%s', $key, $value),
+                array_keys($X509Issuer),
+                $X509Issuer
+            )
+        );
     }
 
 }


### PR DESCRIPTION
Expected key `'OU'` is not always present in the cert data.
This way of handling should dynamically compose issuer name.
