### PR TITLE
Add handler for converting hex value to number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "nesbot/carbon": "2.*",
         "ext-openssl": "*",
         "ext-dom": "*",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-bcmath": "*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",

--- a/src/Fiskalizacija.php
+++ b/src/Fiskalizacija.php
@@ -1,4 +1,6 @@
-<?php namespace Nticaric\Fiskalizacija;
+<?php
+
+namespace Nticaric\Fiskalizacija;
 
 /**
  *
@@ -94,6 +96,9 @@ class Fiskalizacija
 
         $X509IssuerName = $this->getIssuerName();
         $X509IssuerSerial = $this->publicCertificateData['serialNumber'];
+        if (strpos($X509IssuerSerial, '0x') === 0) {
+            $X509IssuerSerial = $this->bchexdec($X509IssuerSerial);
+        }
 
         $publicCertificatePureString = str_replace('-----BEGIN CERTIFICATE-----', '', $this->certificate['cert']);
         $publicCertificatePureString = str_replace('-----END CERTIFICATE-----', '', $publicCertificatePureString);
@@ -296,4 +301,15 @@ class Fiskalizacija
         );
     }
 
+    public function bchexdec($hex): string
+    {
+        $dec = 0;
+        $len = strlen($hex);
+
+        for ($i = 1; $i <= $len; $i++) {
+            $dec = bcadd($dec, bcmul((string) hexdec($hex[$i - 1]), bcpow('16', (string) ($len - $i))));
+        }
+
+        return $dec;
+    }
 }


### PR DESCRIPTION
`.p12` file (certificate) can contain hex values for `serialNumber` param.
Handler added to convert it to number